### PR TITLE
Retry `html_read` on HTTP error

### DIFF
--- a/data-raw/functions.R
+++ b/data-raw/functions.R
@@ -19,5 +19,5 @@ read_html_safe <- function(url, tries)
     tries <- tries - 1
   }
 
- return(res_html)
+  return(res_html)
 }

--- a/data-raw/functions.R
+++ b/data-raw/functions.R
@@ -1,0 +1,23 @@
+library(xml2)
+
+read_html_safe <- function(url, tries)
+{
+  res_html <- NULL
+  while (tries > 0 & is.null(res_html))
+  {
+    tryCatch(
+    {
+      res_html <- read_html(url)
+      break()
+    }
+    ,
+    error = function(e)
+    {
+      message(paste(e, url))
+    }
+    )
+    tries <- tries - 1
+  }
+
+ return(res_html)
+}

--- a/data-raw/get_rider_profiles.R
+++ b/data-raw/get_rider_profiles.R
@@ -4,10 +4,11 @@ library(rvest)
 library(xml2)
 library(tidyr)
 
+source("data-raw/functions.R")
 
 get_ranking_id <- function(url)
 {
-  site <- read_html(url)
+  site <- read_html_safe(url, 3)
 
   rankings_id <-
     site %>%
@@ -22,7 +23,7 @@ get_ranking_id <- function(url)
 
 
 get_profs <- function(url){
-  site <- read_html(url)
+  site <- read_html_safe(url, 3)
   current_rankings <- 
     site %>% 
     html_nodes(xpath = '//*[contains(concat( " ", @class, " " ), concat( " ", "statDivLeft", " " ))]') %>% 
@@ -55,7 +56,7 @@ get_profs <- function(url){
   for (i in 1:length(rider_urls)){
     Sys.sleep(0.5)
     url <- paste0("https://www.procyclingstats.com/rider/",rider_urls[i])
-    rider_html <- read_html(url) 
+    rider_html <- read_html_safe(url, 3)
     
     rider_metadata <- 
       rider_html %>% 

--- a/data-raw/get_rider_stats.R
+++ b/data-raw/get_rider_stats.R
@@ -5,9 +5,11 @@ library(stringr)
 library(tidyr)
 library(readr)
 
+source("data-raw/functions.R")
+
 get_ranking_id <- function(url)
 {
-  site <- read_html(url)
+  site <- read_html_safe(url, 3)
   
   rankings_id <-
     site %>%
@@ -21,7 +23,7 @@ get_ranking_id <- function(url)
 }
 
 get_rider_stats <- function(url){
-  site <- read_html(url)
+  site <- read_html_safe(url, 3)
   
   current_rankings <- 
     site %>% 
@@ -60,7 +62,7 @@ get_rider_stats <- function(url){
   for (i in 1:length(rider_urls)){
     Sys.sleep(0.25)
     url <- paste0("https://www.procyclingstats.com/rider/",rider_urls[i])
-    rider_html <- read_html(url) 
+    rider_html <- read_html_safe(url, 3)
     
     rider_metadata <- 
       rider_html %>% 
@@ -89,7 +91,7 @@ get_rider_stats <- function(url){
       
       message(paste(rider, seasons[j]))
       rider_season_url <- paste0(url, "/", seasons[j])
-      rider_season_site <- read_html(rider_season_url)
+      rider_season_site <- read_html_safe(rider_season_url, 3)
       rider_season_table <- rider_season_site %>% 
         html_nodes("table") %>%
         .[[1]] %>%


### PR DESCRIPTION
Scrapping session fails if `html_read` yields error (e.g. timeout).

Proposed change introduces retry counter.